### PR TITLE
Allow for multiple platform images to be pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
 on:
+  workflow_dispatch:
+    ref: main
   push:
     tags:
       - v*
@@ -37,9 +39,17 @@ jobs:
           publish_dir: ${{ env.WORKSPACE_BUILD_DIR }}
           keep_files: true
 
-  build-push-docker-image:
+  build-docker-image:
     name: Build and push Docker image
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+          - platform: linux/arm64
+            arch: arm64
     permissions:
       contents: read
       packages: write
@@ -47,6 +57,13 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
     steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          image=${{ env.IMAGE_NAME }}
+          echo "DIGEST_PREFIX=${image//\//-}" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -74,10 +91,87 @@ jobs:
             org.opencontainers.image.vendor=ConduitIO
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.9.0
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.DIGEST_PREFIX }}-digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Remove creds file
+        # always runs to delete creds file, regardless of prior steps
+        if: always()
+        run: rm .git-credentials
+
+  merge-push-docker-image:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Prepare
+        run: |
+          image=${{ env.IMAGE_NAME }}
+          echo "DIGEST_PREFIX=${image//\//-}" >> $GITHUB_ENV
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: ${{ env.DIGEST_PREFIX }}-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{raw}}
+            type=raw,value=latest-nightly,enable=${{ contains(github.ref, '-nightly')  }}
+            type=semver,pattern=v{{major}}.{{minor}},enable=${{ !contains(github.ref, '-nightly') }}
+            type=semver,pattern=v{{major}},enable=${{ !contains(github.ref, '-nightly') && !startsWith(github.ref, 'refs/tags/v0.') }}
+          labels: |
+            maintainer=ConduitIO
+            org.opencontainers.image.title=Conduit-Operator
+            org.opencontainers.image.description=Conduit Operator manages Conduit instances on Kubernetes
+            org.opencontainers.image.vendor=ConduitIO
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ matrix.image }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
### Description

The only option right now is amd64, this adds arm64

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/conduitio/conduit-operator/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
