### PR TITLE
Fix refernce, registry can be nil when schema is not used

### DIFF
--- a/api/v1alpha/conduit_webhook.go
+++ b/api/v1alpha/conduit_webhook.go
@@ -201,6 +201,10 @@ func validateConduitVersion(ver string) bool {
 }
 
 func validateRegistry(sr *SchemaRegistry) error {
+	if sr == nil {
+		return nil
+	}
+
 	if sr.URL == "" {
 		return nil
 	}


### PR DESCRIPTION
### Description

Schema registry configuration may be not set. Validation may panic with nil reference.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio/conduit-operator/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
