### PR TITLE
Revert "chore: update to 0.13"

### DIFF
--- a/controllers/conduit_containers.go
+++ b/controllers/conduit_containers.go
@@ -134,12 +134,11 @@ func ConduitInitContainers(cc []*v1alpha.ConduitConnector) []corev1.Container {
 func ConduitRuntimeContainer(image, version string, envVars []corev1.EnvVar) corev1.Container {
 	args := []string{
 		"/app/conduit",
-		"run",
 		"-pipelines.path", v1alpha.ConduitPipelineFile,
 		"-connectors.path", v1alpha.ConduitConnectorsPath,
 		"-db.type", "sqlite",
 		"-db.sqlite.path", v1alpha.ConduitDBPath,
-		"-pipelines.exit-on-degraded",
+		"-pipelines.exit-on-error",
 		"-processors.path", v1alpha.ConduitProcessorsPath,
 	}
 

--- a/controllers/conduit_containers_test.go
+++ b/controllers/conduit_containers_test.go
@@ -197,12 +197,11 @@ func Test_ConduitRuntimeContainer(t *testing.T) {
 		ImagePullPolicy: corev1.PullAlways,
 		Args: []string{
 			"/app/conduit",
-			"run",
 			"-pipelines.path", "/conduit.pipelines/pipeline.yaml",
 			"-connectors.path", "/conduit.storage/connectors",
 			"-db.type", "sqlite",
 			"-db.sqlite.path", "/conduit.storage/db",
-			"-pipelines.exit-on-degraded",
+			"-pipelines.exit-on-error",
 			"-processors.path",
 			"/conduit.storage/processors",
 		},


### PR DESCRIPTION
This has changes applicable to v0.13 but the operator is only running v0.11. 
Reverts ConduitIO/conduit-operator#49