### PR TITLE
allow for different args with conduit > 12

### DIFF
--- a/internal/conduit/version.go
+++ b/internal/conduit/version.go
@@ -37,7 +37,10 @@ func (f *Flags) ForVersion(ver string) ([]string, error) {
 	v, _ := semver.NewVersion(sanitized)
 
 	for key, rule := range constraints {
-		c, _ := semver.NewConstraint(rule)
+		c, err := semver.NewConstraint(rule)
+		if err != nil {
+			return nil, fmt.Errorf("parse error occured while creating constraint: %w", err)
+		}
 		if c.Check(v) {
 			switch key {
 			case "v011":

--- a/internal/conduit/version.go
+++ b/internal/conduit/version.go
@@ -1,0 +1,30 @@
+package conduit
+
+// ArgsByVersion returns the args needed for creating the
+// runtime container depending on the conduit version.
+func ArgsByVersion(version string, pipelineFile string, connectorsPath string, dbPath string, processorsPath string) []string {
+	var args []string
+	if version < "v0.12.0" {
+		args = []string{
+			"/app/conduit",
+			"-pipelines.path", pipelineFile,
+			"-connectors.path", connectorsPath,
+			"-db.type", "sqlite",
+			"-db.sqlite.path", dbPath,
+			"-pipelines.exit-on-error",
+			"-processors.path", processorsPath,
+		}
+	} else {
+		args = []string{
+			"/app/conduit",
+			"--pipelines.path", pipelineFile,
+			"--connectors.path", connectorsPath,
+			"--db.type", "sqlite",
+			"--db.sqlite.path", dbPath,
+			"--pipelines.exit-on-degraded",
+			"--processors.path", processorsPath,
+		}
+	}
+
+	return args
+}

--- a/internal/conduit/version.go
+++ b/internal/conduit/version.go
@@ -50,7 +50,6 @@ func (f *Flags) ForVersion(ver string) []string {
 
 func (f *Flags) v011() []string {
 	return []string{
-		"/app/conduit",
 		"-pipelines.path", f.args.PipelineFile,
 		"-connectors.path", f.args.ConnectorsPath,
 		"-db.type", "sqlite",
@@ -62,7 +61,6 @@ func (f *Flags) v011() []string {
 
 func (f *Flags) v012() []string {
 	return []string{
-		"/app/conduit",
 		"--pipelines.path", f.args.PipelineFile,
 		"--connectors.path", f.args.ConnectorsPath,
 		"--db.type", "sqlite",
@@ -74,7 +72,7 @@ func (f *Flags) v012() []string {
 
 func (f *Flags) v013() []string {
 	return []string{
-		"/app/conduit run",
+		"run",
 		"--pipelines.path", f.args.PipelineFile,
 		"--connectors.path", f.args.ConnectorsPath,
 		"--db.type", "sqlite",

--- a/internal/conduit/version.go
+++ b/internal/conduit/version.go
@@ -49,7 +49,7 @@ func (f *Flags) ForVersion(ver string) ([]string, error) {
 			}
 		}
 	}
-	return nil, fmt.Errorf("Version %s not supported", ver)
+	return nil, fmt.Errorf("version %s not supported", ver)
 }
 
 func (f *Flags) v011() []string {

--- a/internal/conduit/version.go
+++ b/internal/conduit/version.go
@@ -1,6 +1,7 @@
 package conduit
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -25,10 +26,11 @@ func NewFlags(fns ...func(*Args)) *Flags {
 	return &Flags{args: &args}
 }
 
-func (f *Flags) ForVersion(ver string) []string {
+func (f *Flags) ForVersion(ver string) ([]string, error) {
 	constraints := map[string]string{
-		"v011": "< 0.12.0",
-		"v012": ">= 0.12.0, < 0.13.0",
+		"v011": "~0.11.1",
+		"v012": "~0.12.x",
+		"v013": "~0.13.x",
 	}
 
 	sanitized, _ := strings.CutPrefix(ver, "v")
@@ -39,13 +41,15 @@ func (f *Flags) ForVersion(ver string) []string {
 		if c.Check(v) {
 			switch key {
 			case "v011":
-				return f.v011()
+				return f.v011(), nil
 			case "v012":
-				return f.v012()
+				return f.v012(), nil
+			case "v013":
+				return f.v013(), nil
 			}
 		}
 	}
-	return f.v013()
+	return nil, fmt.Errorf("Version %s not supported", ver)
 }
 
 func (f *Flags) v011() []string {

--- a/internal/conduit/version_test.go
+++ b/internal/conduit/version_test.go
@@ -41,6 +41,18 @@ func Test_ForVersion(t *testing.T) {
 			},
 		},
 		{
+			name:    "with a patched version of 0.12",
+			version: "v0.12.4",
+			want: []string{
+				"--pipelines.path", "/conduit.pipelines/pipeline.yaml",
+				"--connectors.path", "/conduit.storage/connectors",
+				"--db.type", "sqlite",
+				"--db.sqlite.path", "/conduit.storage/db",
+				"--pipelines.exit-on-degraded",
+				"--processors.path", "/conduit.storage/processors",
+			},
+		},
+		{
 			name:    "with version greater than 0.12",
 			version: "v0.13.0",
 			want: []string{

--- a/internal/conduit/version_test.go
+++ b/internal/conduit/version_test.go
@@ -57,7 +57,7 @@ func Test_ForVersion(t *testing.T) {
 			name:    "with an unsupported version",
 			version: "v0.14.0",
 			want:    nil,
-			wantErr: errors.Errorf("Version v0.14.0 not supported"),
+			wantErr: errors.Errorf("version v0.14.0 not supported"),
 		},
 	}
 

--- a/internal/conduit/version_test.go
+++ b/internal/conduit/version_test.go
@@ -72,7 +72,6 @@ func Test_ForVersion(t *testing.T) {
 				conduit.WithProcessorsPath(v1alpha.ConduitProcessorsPath),
 			)
 			args, err := flags.ForVersion(tc.version)
-
 			if err != nil {
 				is.Equal(tc.wantErr.Error(), err.Error())
 			}

--- a/internal/conduit/version_test.go
+++ b/internal/conduit/version_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/matryer/is"
 )
 
-func Test_ArgsByVersion(t *testing.T) {
+func Test_ForVersion(t *testing.T) {
 	tests := []struct {
 		name    string
 		version string
@@ -46,13 +46,13 @@ func Test_ArgsByVersion(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			is := is.New(t)
 
-			args := conduit.ArgsByVersion(
-				tc.version,
-				v1alpha.ConduitPipelineFile,
-				v1alpha.ConduitConnectorsPath,
-				v1alpha.ConduitDBPath,
-				v1alpha.ConduitProcessorsPath,
+			flags := conduit.NewFlags(
+				conduit.WithPipelineFile(v1alpha.ConduitPipelineFile),
+				conduit.WithConnectorsPath(v1alpha.ConduitConnectorsPath),
+				conduit.WithDBPath(v1alpha.ConduitDBPath),
+				conduit.WithProcessorsPath(v1alpha.ConduitProcessorsPath),
 			)
+			args := flags.ForVersion(tc.version)
 
 			is.Equal(args, tc.want)
 		})

--- a/internal/conduit/version_test.go
+++ b/internal/conduit/version_test.go
@@ -28,10 +28,23 @@ func Test_ForVersion(t *testing.T) {
 			},
 		},
 		{
-			name:    "with version more than 0.12",
+			name:    "with version of 0.12",
 			version: "v0.12.0",
 			want: []string{
 				"/app/conduit",
+				"--pipelines.path", "/conduit.pipelines/pipeline.yaml",
+				"--connectors.path", "/conduit.storage/connectors",
+				"--db.type", "sqlite",
+				"--db.sqlite.path", "/conduit.storage/db",
+				"--pipelines.exit-on-degraded",
+				"--processors.path", "/conduit.storage/processors",
+			},
+		},
+		{
+			name:    "with version greater than 0.12",
+			version: "v0.13.0",
+			want: []string{
+				"/app/conduit run",
 				"--pipelines.path", "/conduit.pipelines/pipeline.yaml",
 				"--connectors.path", "/conduit.storage/connectors",
 				"--db.type", "sqlite",

--- a/internal/conduit/version_test.go
+++ b/internal/conduit/version_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/conduitio/conduit-operator/api/v1alpha"
 	"github.com/conduitio/conduit-operator/internal/conduit"
 	"github.com/matryer/is"
+	"github.com/pkg/errors"
 )
 
 func Test_ForVersion(t *testing.T) {
@@ -13,6 +14,7 @@ func Test_ForVersion(t *testing.T) {
 		name    string
 		version string
 		want    []string
+		wantErr error
 	}{
 		{
 			name:    "with version less than 0.12",
@@ -51,6 +53,12 @@ func Test_ForVersion(t *testing.T) {
 				"--processors.path", "/conduit.storage/processors",
 			},
 		},
+		{
+			name:    "with an unsupported version",
+			version: "v0.14.0",
+			want:    nil,
+			wantErr: errors.Errorf("Version v0.14.0 not supported"),
+		},
 	}
 
 	for _, tc := range tests {
@@ -63,8 +71,11 @@ func Test_ForVersion(t *testing.T) {
 				conduit.WithDBPath(v1alpha.ConduitDBPath),
 				conduit.WithProcessorsPath(v1alpha.ConduitProcessorsPath),
 			)
-			args := flags.ForVersion(tc.version)
+			args, err := flags.ForVersion(tc.version)
 
+			if err != nil {
+				is.Equal(tc.wantErr.Error(), err.Error())
+			}
 			is.Equal(args, tc.want)
 		})
 	}

--- a/internal/conduit/version_test.go
+++ b/internal/conduit/version_test.go
@@ -18,7 +18,6 @@ func Test_ForVersion(t *testing.T) {
 			name:    "with version less than 0.12",
 			version: "v0.11.1",
 			want: []string{
-				"/app/conduit",
 				"-pipelines.path", "/conduit.pipelines/pipeline.yaml",
 				"-connectors.path", "/conduit.storage/connectors",
 				"-db.type", "sqlite",
@@ -31,7 +30,6 @@ func Test_ForVersion(t *testing.T) {
 			name:    "with version of 0.12",
 			version: "v0.12.0",
 			want: []string{
-				"/app/conduit",
 				"--pipelines.path", "/conduit.pipelines/pipeline.yaml",
 				"--connectors.path", "/conduit.storage/connectors",
 				"--db.type", "sqlite",
@@ -44,7 +42,7 @@ func Test_ForVersion(t *testing.T) {
 			name:    "with version greater than 0.12",
 			version: "v0.13.0",
 			want: []string{
-				"/app/conduit run",
+				"run",
 				"--pipelines.path", "/conduit.pipelines/pipeline.yaml",
 				"--connectors.path", "/conduit.storage/connectors",
 				"--db.type", "sqlite",

--- a/internal/conduit/version_test.go
+++ b/internal/conduit/version_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/conduitio/conduit-operator/api/v1alpha"
-	"github.com/conduitio/conduit-operator/pkg/conduit"
+	"github.com/conduitio/conduit-operator/internal/conduit"
 	"github.com/matryer/is"
 )
 

--- a/internal/conduit/version_test.go
+++ b/internal/conduit/version_test.go
@@ -1,0 +1,60 @@
+package conduit_test
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit-operator/api/v1alpha"
+	"github.com/conduitio/conduit-operator/pkg/conduit"
+	"github.com/matryer/is"
+)
+
+func Test_ArgsByVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    []string
+	}{
+		{
+			name:    "with version less than 0.12",
+			version: "v0.11.1",
+			want: []string{
+				"/app/conduit",
+				"-pipelines.path", "/conduit.pipelines/pipeline.yaml",
+				"-connectors.path", "/conduit.storage/connectors",
+				"-db.type", "sqlite",
+				"-db.sqlite.path", "/conduit.storage/db",
+				"-pipelines.exit-on-error",
+				"-processors.path", "/conduit.storage/processors",
+			},
+		},
+		{
+			name:    "with version more than 0.12",
+			version: "v0.12.0",
+			want: []string{
+				"/app/conduit",
+				"--pipelines.path", "/conduit.pipelines/pipeline.yaml",
+				"--connectors.path", "/conduit.storage/connectors",
+				"--db.type", "sqlite",
+				"--db.sqlite.path", "/conduit.storage/db",
+				"--pipelines.exit-on-degraded",
+				"--processors.path", "/conduit.storage/processors",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+
+			args := conduit.ArgsByVersion(
+				tc.version,
+				v1alpha.ConduitPipelineFile,
+				v1alpha.ConduitConnectorsPath,
+				v1alpha.ConduitDBPath,
+				v1alpha.ConduitProcessorsPath,
+			)
+
+			is.Equal(args, tc.want)
+		})
+	}
+}

--- a/internal/controller/conduit_containers.go
+++ b/internal/controller/conduit_containers.go
@@ -131,15 +131,17 @@ func ConduitInitContainers(cc []*v1alpha.ConduitConnector) []corev1.Container {
 }
 
 // ConduitRuntimeContainer returns a Kubernetes container definition
-// todo is the pipelineName supposed to be used?
-func ConduitRuntimeContainer(image, version string, envVars []corev1.EnvVar) corev1.Container {
+func ConduitRuntimeContainer(image, version string, envVars []corev1.EnvVar) (corev1.Container, error) {
 	flags := conduit.NewFlags(
 		conduit.WithPipelineFile(v1alpha.ConduitPipelineFile),
 		conduit.WithConnectorsPath(v1alpha.ConduitConnectorsPath),
 		conduit.WithDBPath(v1alpha.ConduitDBPath),
 		conduit.WithProcessorsPath(v1alpha.ConduitProcessorsPath),
 	)
-	args := flags.ForVersion(version)
+	args, err := flags.ForVersion(version)
+	if err != nil {
+		return corev1.Container{}, err
+	}
 
 	return corev1.Container{
 		Name:            v1alpha.ConduitContainerName,
@@ -184,5 +186,5 @@ func ConduitRuntimeContainer(image, version string, envVars []corev1.EnvVar) cor
 			},
 		},
 		Env: envVars,
-	}
+	}, nil
 }

--- a/internal/controller/conduit_containers.go
+++ b/internal/controller/conduit_containers.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	v1alpha "github.com/conduitio/conduit-operator/api/v1alpha"
+	"github.com/conduitio/conduit-operator/pkg/conduit"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -132,15 +133,13 @@ func ConduitInitContainers(cc []*v1alpha.ConduitConnector) []corev1.Container {
 // ConduitRuntimeContainer returns a Kubernetes container definition
 // todo is the pipelineName supposed to be used?
 func ConduitRuntimeContainer(image, version string, envVars []corev1.EnvVar) corev1.Container {
-	args := []string{
-		"/app/conduit",
-		"-pipelines.path", v1alpha.ConduitPipelineFile,
-		"-connectors.path", v1alpha.ConduitConnectorsPath,
-		"-db.type", "sqlite",
-		"-db.sqlite.path", v1alpha.ConduitDBPath,
-		"-pipelines.exit-on-error",
-		"-processors.path", v1alpha.ConduitProcessorsPath,
-	}
+	args := conduit.ArgsByVersion(
+		version,
+		v1alpha.ConduitPipelineFile,
+		v1alpha.ConduitConnectorsPath,
+		v1alpha.ConduitDBPath,
+		v1alpha.ConduitProcessorsPath,
+	)
 
 	return corev1.Container{
 		Name:            v1alpha.ConduitContainerName,

--- a/internal/controller/conduit_containers.go
+++ b/internal/controller/conduit_containers.go
@@ -145,6 +145,7 @@ func ConduitRuntimeContainer(image, version string, envVars []corev1.EnvVar) cor
 		Name:            v1alpha.ConduitContainerName,
 		Image:           fmt.Sprint(image, ":", version),
 		ImagePullPolicy: corev1.PullAlways,
+		Command:         []string{"/app/conduit"},
 		Args:            args,
 		Ports: []corev1.ContainerPort{
 			{

--- a/internal/controller/conduit_containers.go
+++ b/internal/controller/conduit_containers.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	v1alpha "github.com/conduitio/conduit-operator/api/v1alpha"
-	"github.com/conduitio/conduit-operator/pkg/conduit"
+	"github.com/conduitio/conduit-operator/internal/conduit"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/controller/conduit_containers.go
+++ b/internal/controller/conduit_containers.go
@@ -133,13 +133,13 @@ func ConduitInitContainers(cc []*v1alpha.ConduitConnector) []corev1.Container {
 // ConduitRuntimeContainer returns a Kubernetes container definition
 // todo is the pipelineName supposed to be used?
 func ConduitRuntimeContainer(image, version string, envVars []corev1.EnvVar) corev1.Container {
-	args := conduit.ArgsByVersion(
-		version,
-		v1alpha.ConduitPipelineFile,
-		v1alpha.ConduitConnectorsPath,
-		v1alpha.ConduitDBPath,
-		v1alpha.ConduitProcessorsPath,
+	flags := conduit.NewFlags(
+		conduit.WithPipelineFile(v1alpha.ConduitPipelineFile),
+		conduit.WithConnectorsPath(v1alpha.ConduitConnectorsPath),
+		conduit.WithDBPath(v1alpha.ConduitDBPath),
+		conduit.WithProcessorsPath(v1alpha.ConduitProcessorsPath),
 	)
+	args := flags.ForVersion(version)
 
 	return corev1.Container{
 		Name:            v1alpha.ConduitContainerName,

--- a/internal/controller/conduit_containers_test.go
+++ b/internal/controller/conduit_containers_test.go
@@ -270,7 +270,7 @@ func Test_ConduitRuntimeContainer(t *testing.T) {
 			name:    "error occurs creating runtime container",
 			version: "v0.14.0",
 			want:    corev1.Container{},
-			wantErr: errors.Errorf("Version v0.14.0 not supported"),
+			wantErr: errors.Errorf("version v0.14.0 not supported"),
 		},
 	}
 

--- a/internal/controller/conduit_containers_test.go
+++ b/internal/controller/conduit_containers_test.go
@@ -194,8 +194,8 @@ func Test_ConduitRuntimeContainer(t *testing.T) {
 		Name:            "conduit-server",
 		Image:           "my-image:v0.11.1",
 		ImagePullPolicy: corev1.PullAlways,
+		Command:         []string{"/app/conduit"},
 		Args: []string{
-			"/app/conduit",
 			"-pipelines.path", "/conduit.pipelines/pipeline.yaml",
 			"-connectors.path", "/conduit.storage/connectors",
 			"-db.type", "sqlite",

--- a/internal/controller/conduit_containers_test.go
+++ b/internal/controller/conduit_containers_test.go
@@ -292,7 +292,6 @@ func Test_ConduitRuntimeContainer(t *testing.T) {
 					},
 				},
 			)
-
 			if err != nil {
 				is.Equal(tc.wantErr.Error(), err.Error())
 			}

--- a/internal/controller/conduit_controller.go
+++ b/internal/controller/conduit_controller.go
@@ -339,6 +339,12 @@ func (r *ConduitReconciler) CreateOrUpdateDeployment(ctx context.Context, c *v1.
 			})
 		}
 
+		// fmt.Printf("version %s", c.Spec.Version)
+		container, err := ConduitRuntimeContainer(c.Spec.Image, c.Spec.Version, envVars)
+		if err != nil {
+			return err
+		}
+
 		spec := appsv1.DeploymentSpec{
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,
@@ -351,7 +357,7 @@ func (r *ConduitReconciler) CreateOrUpdateDeployment(ctx context.Context, c *v1.
 					RestartPolicy:  corev1.RestartPolicyAlways,
 					InitContainers: ConduitInitContainers(c.Spec.Connectors),
 					Containers: []corev1.Container{
-						ConduitRuntimeContainer(c.Spec.Image, c.Spec.Version, envVars),
+						container,
 					},
 					Volumes: []corev1.Volume{
 						ConduitVolume(nn.Name),


### PR DESCRIPTION
### Description

Add compatibility for conduit 0.12 and 0.13 to accommodate updates in flags. This will allow for future conduit upgrades.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio/conduit-operator/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
