### PR TITLE
use JSON logging for conduit logs

### DIFF
--- a/internal/controller/conduit_containers_test.go
+++ b/internal/controller/conduit_containers_test.go
@@ -205,6 +205,7 @@ func Test_ConduitRuntimeContainer(t *testing.T) {
 			"--db.sqlite.path", "/conduit.storage/db",
 			"--pipelines.exit-on-degraded",
 			"--processors.path", "/conduit.storage/processors",
+			"--log.format", "json",
 		},
 		Ports: []corev1.ContainerPort{
 			{

--- a/pkg/conduit/version.go
+++ b/pkg/conduit/version.go
@@ -63,6 +63,7 @@ func (f *Flags) v011() []string {
 		"-db.sqlite.path", f.args.DBPath,
 		"-pipelines.exit-on-error",
 		"-processors.path", f.args.ProcessorsPath,
+		"-log.format", "json",
 	}
 }
 
@@ -74,6 +75,7 @@ func (f *Flags) v012() []string {
 		"--db.sqlite.path", f.args.DBPath,
 		"--pipelines.exit-on-degraded",
 		"--processors.path", f.args.ProcessorsPath,
+		"--log.format", "json",
 	}
 }
 
@@ -86,6 +88,7 @@ func (f *Flags) v013() []string {
 		"--db.sqlite.path", f.args.DBPath,
 		"--pipelines.exit-on-degraded",
 		"--processors.path", f.args.ProcessorsPath,
+		"--log.format", "json",
 	}
 }
 

--- a/pkg/conduit/version_test.go
+++ b/pkg/conduit/version_test.go
@@ -25,6 +25,7 @@ func Test_ForVersion(t *testing.T) {
 				"-db.sqlite.path", "/conduit.storage/db",
 				"-pipelines.exit-on-error",
 				"-processors.path", "/conduit.storage/processors",
+				"-log.format", "json",
 			},
 		},
 		{
@@ -37,6 +38,7 @@ func Test_ForVersion(t *testing.T) {
 				"--db.sqlite.path", "/conduit.storage/db",
 				"--pipelines.exit-on-degraded",
 				"--processors.path", "/conduit.storage/processors",
+				"--log.format", "json",
 			},
 		},
 		{
@@ -49,6 +51,7 @@ func Test_ForVersion(t *testing.T) {
 				"--db.sqlite.path", "/conduit.storage/db",
 				"--pipelines.exit-on-degraded",
 				"--processors.path", "/conduit.storage/processors",
+				"--log.format", "json",
 			},
 		},
 		{
@@ -62,6 +65,7 @@ func Test_ForVersion(t *testing.T) {
 				"--db.sqlite.path", "/conduit.storage/db",
 				"--pipelines.exit-on-degraded",
 				"--processors.path", "/conduit.storage/processors",
+				"--log.format", "json",
 			},
 		},
 		{


### PR DESCRIPTION
### Description

Use JSON logging for conduit logs. This will make it a bit easier for machine parsing of the logs.

Fixes # (issue)

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio/conduit-operator/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
