### PR TITLE
Bump conduit version which fixes config env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ kind_setup: kind_cluster
 
 .PHONY: kind_image_build
 kind_image_build: docker_build
+	@sleep 2 # this is required to allow for docker deskop on mac to settle with the image
 	kind load docker-image $(IMG) -n $(KIND_CLUSTER)
 
 .PHONY: dev_delete

--- a/api/v1alpha/conduit_types.go
+++ b/api/v1alpha/conduit_types.go
@@ -42,7 +42,7 @@ var ConduitConditions = NewConditionSet(
 )
 
 const (
-	ConduitVersion             = "v0.13.2"
+	ConduitVersion             = "v0.13.4"
 	ConduitImage               = "ghcr.io/conduitio/conduit"
 	ConduitContainerName       = "conduit-server"
 	ConduitPipelinePath        = "/conduit.pipelines"
@@ -58,7 +58,7 @@ const (
 
 var (
 	ConduitPipelineFile      = path.Join(ConduitPipelinePath, "pipeline.yaml")
-	ConduitEarliestAvailable = "v0.13.2"
+	ConduitEarliestAvailable = "v0.11.0"
 )
 
 // ConduitSpec defines the desired state of Conduit

--- a/internal/webhook/v1alpha/conduit_webhook_test.go
+++ b/internal/webhook/v1alpha/conduit_webhook_test.go
@@ -24,8 +24,7 @@ func TestWebhookValidate_ConduitVersion(t *testing.T) {
 	}{
 		{ver: "v0.13.2", expectedErr: nil},
 		{ver: "v1", expectedErr: nil},
-		{ver: "v0.11.1", expectedErr: fmt.Errorf(`spec.version: Invalid value: "v0.11.1": unsupported conduit version "v0.11.1", minimum required "v0.13.2"`)},
-		{ver: "v0.12", expectedErr: fmt.Errorf(`spec.version: Invalid value: "v0.12": unsupported conduit version "v0.12", minimum required "v0.13.2"`)},
+		{ver: "v0.10.2", expectedErr: fmt.Errorf(`spec.version: Invalid value: "v0.10.2": unsupported conduit version "v0.10.2", minimum required "v0.11.0"`)},
 	}
 
 	testname := func(err error, ver string) string {

--- a/pkg/conduit/version.go
+++ b/pkg/conduit/version.go
@@ -28,7 +28,7 @@ func NewFlags(fns ...func(*Args)) *Flags {
 
 func (f *Flags) ForVersion(ver string) ([]string, error) {
 	constraints := map[string]string{
-		"v011": "~0.11.1",
+		"v011": "~0.11.x",
 		"v012": "~0.12.x",
 		"v013": "~0.13.x",
 	}


### PR DESCRIPTION
### Description

For v0.13.x config env variables stopped working, v0.13.4 fixes this.

Adjust the earliest available version based on the versioning we support.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio/conduit-operator/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
