### PR TITLE
Expose gRPC port in the service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CERT_MANAGER      := https://github.com/cert-manager/cert-manager/releases/downl
 KUSTOMIZE_VERSION ?= v5.5.0
 CTRL_GEN_VERSION  ?= v0.17.2
 KIND_VERSION      ?= v0.27.0
-GOLINT_VERSION    ?= v1.63.4
+GOLINT_VERSION    ?= v1.64.8
 
 .EXPORT_ALL_VARIABLES:
 
@@ -101,7 +101,7 @@ docker_push: docker_build
 
 ## Tooling for running the operator in a local kubernetes cluster
 
-bin/kind: 
+bin/kind:
 	GOBIN=$(PWD)/bin go install sigs.k8s.io/kind/cmd/kind@$(KIND_VERSION)
 
 .PHONY: kind

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conduitio/conduit-operator
 
-go 1.23.6
+go 1.24.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
@@ -13,6 +13,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/matryer/is v1.4.1
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250228200357-dead58393ab7
 	gopkg.in/yaml.v3 v3.0.1
@@ -334,7 +335,6 @@ require (
 	github.com/stealthrocket/wazergo v0.19.1 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tdakkota/asciicheck v0.4.1 // indirect
 	github.com/tetafro/godot v1.5.0 // indirect

--- a/internal/controller/conduit_controller.go
+++ b/internal/controller/conduit_controller.go
@@ -491,9 +491,17 @@ func (r *ConduitReconciler) CreateOrUpdateService(ctx context.Context, c *v1.Con
 			{
 				Name:     "http",
 				Protocol: corev1.ProtocolTCP,
-				Port:     80,
+				Port:     8080,
 				TargetPort: intstr.IntOrString{
 					IntVal: 8080,
+				},
+			},
+			{
+				Name:     "grpc",
+				Protocol: corev1.ProtocolTCP,
+				Port:     8084,
+				TargetPort: intstr.IntOrString{
+					IntVal: 8084,
 				},
 			},
 		}
@@ -505,7 +513,7 @@ func (r *ConduitReconciler) CreateOrUpdateService(ctx context.Context, c *v1.Con
 			v1.ConditionConduitServiceReady,
 			corev1.ConditionTrue,
 			"ServiceReady",
-			fmt.Sprintf("Address http://%s:80", service.Spec.ClusterIP),
+			fmt.Sprintf("Address http://%[1]s:8080 grpc://%[1]s:8084", service.Spec.ClusterIP),
 		)
 		return ctrlutil.SetControllerReference(c, &service, r.Scheme())
 	}

--- a/internal/controller/conduit_controller_test.go
+++ b/internal/controller/conduit_controller_test.go
@@ -682,9 +682,17 @@ func Test_CreateOrUpdateService(t *testing.T) {
 						{
 							Name:     "http",
 							Protocol: corev1.ProtocolTCP,
-							Port:     80,
+							Port:     8080,
 							TargetPort: intstr.IntOrString{
 								IntVal: 8080,
+							},
+						},
+						{
+							Name:     "grpc",
+							Protocol: corev1.ProtocolTCP,
+							Port:     8084,
+							TargetPort: intstr.IntOrString{
+								IntVal: 8084,
 							},
 						},
 					},
@@ -733,9 +741,17 @@ func Test_CreateOrUpdateService(t *testing.T) {
 						{
 							Name:     "http",
 							Protocol: corev1.ProtocolTCP,
-							Port:     80,
+							Port:     8080,
 							TargetPort: intstr.IntOrString{
 								IntVal: 8080,
+							},
+						},
+						{
+							Name:     "grpc",
+							Protocol: corev1.ProtocolTCP,
+							Port:     8084,
+							TargetPort: intstr.IntOrString{
+								IntVal: 8084,
 							},
 						},
 					},


### PR DESCRIPTION
### Description

Expose gRPC port from conduit and move http to 8080
Update golang to 1.24 and linter.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/conduitio/conduit-operator/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
