### PR TITLE
feat(helm): make operator resources configurable

### DIFF
--- a/charts/conduit-operator/Chart.yaml
+++ b/charts/conduit-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conduit-operator
 description: A Helm chart for the Conduit data stream tool
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: "0.0.4"

--- a/charts/conduit-operator/templates/deployment.yaml
+++ b/charts/conduit-operator/templates/deployment.yaml
@@ -53,16 +53,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          {{- with .Values.resources }}
-          {{- toYaml . | nindent 10 }}
-          {{- else }}
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
-          {{- end }}
+          {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/conduit-operator/templates/deployment.yaml
+++ b/charts/conduit-operator/templates/deployment.yaml
@@ -53,12 +53,16 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
+          {{- with .Values.resources }}
+          {{- toYaml . | nindent 10 }}
+          {{- else }}
           limits:
             cpu: 500m
             memory: 128Mi
           requests:
             cpu: 10m
             memory: 64Mi
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/conduit-operator/test-values.yaml
+++ b/charts/conduit-operator/test-values.yaml
@@ -1,0 +1,7 @@
+# resources:
+#   limits:
+#     cpu: 1000m
+#     memory: 256Mi
+#   requests:
+#     cpu: 100m
+#     memory: 128Mi 


### PR DESCRIPTION
### Description
This change allows users to customize the operator's resource requirements.

- Make CPU and memory limits/requests configurable through values.yaml
- Add default resource values matching previous hardcoded configuration
- Add `test-values.yaml` for testing custom resource configurations

Fixes # (issue)
- https://github.com/ConduitIO/conduit-operator/issues/79

### Testing Plan

```
conduit-operator % helm template . -f test-values.yaml
```

Tested with customized resources in `test-values.yaml`:

with 
```
resources:
  limits:
    cpu: 1000m
    memory: 256Mi
  requests:
    cpu: 100m
    memory: 128Mi 
```
<details>
<summary> Expand to view the rendered manifest: </summary>

```
# Source: conduit-operator/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: 'release-name-conduit-operator'
  namespace: 'staging-fsm'
  labels:
    helm.sh/chart: conduit-operator-0.0.4
    app.kubernetes.io/name: conduit-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.4"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
        app.kubernetes.io/name: conduit-operator
        app.kubernetes.io/instance: release-name
  template:
    metadata:
      annotations:
        # TODO: this is temporarily fix to always rool during redeploy
        rollme: "Wh0oS"
      labels:
        app.kubernetes.io/name: conduit-operator
        app.kubernetes.io/instance: release-name
    spec:
      containers:
      - name: controller
        command:
        - /app/conduit-operator
        args:
        - -webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
        - -metrics-cert-path=/tmp/k8s-metrics-server/serving-certs
        - -zap-devel=true
        - -instance-metadata=/app/instance-config/conduit-pod-metadata.yml
        image: 'ghcr.io/conduitio/conduit-operator:latest'
        imagePullPolicy: 'Always'
        livenessProbe:
          httpGet:
            path: /healthz
            port: 8081
          initialDelaySeconds: 16
          periodSeconds: 20
        ports:
        - containerPort: 9443
          name: webhook-server
          protocol: TCP
        readinessProbe:
          httpGet:
            path: /readyz
            port: 8081
          initialDelaySeconds: 5
          periodSeconds: 10
        resources:
          limits:
            cpu: 1000m
            memory: 256Mi
          requests:
            cpu: 100m
            memory: 128Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
        volumeMounts:
        - mountPath: /tmp/k8s-webhook-server/serving-certs
          name: webhook-cert
          readOnly: true
        - mountPath: /tmp/k8s-metrics-server/serving-certs
          name: metrics-cert
          readOnly: true
        - mountPath: /app/instance-config
          name: 'release-name-conduit-operator-instance-config'
          readOnly: true
      securityContext:
        runAsNonRoot: true
      serviceAccountName: 'release-name-conduit-operator-controller-manager'
      terminationGracePeriodSeconds: 10
      volumes:
      - name: webhook-cert
        secret:
          defaultMode: 420
          secretName: webhook-server-cert
      - name: metrics-cert
        secret:
          defaultMode: 420
          secretName: metrics-server-cert
      - name: 'release-name-conduit-operator-instance-config'
        configMap:
           name: 'release-name-conduit-operator-instance-config'
```
</details>



as well as the default resources: 
```
# resources:
#   limits:
#     cpu: 1000m
#     memory: 256Mi
#   requests:
#     cpu: 100m
#     memory: 128Mi 
```

<details>
<summary>  Expand to view the rendered manifest: </summary>

```
# Source: conduit-operator/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: 'release-name-conduit-operator'
  namespace: 'staging-fsm'
  labels:
    helm.sh/chart: conduit-operator-0.0.4
    app.kubernetes.io/name: conduit-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.4"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
        app.kubernetes.io/name: conduit-operator
        app.kubernetes.io/instance: release-name
  template:
    metadata:
      annotations:
        # TODO: this is temporarily fix to always rool during redeploy
        rollme: "sszvt"
      labels:
        app.kubernetes.io/name: conduit-operator
        app.kubernetes.io/instance: release-name
    spec:
      containers:
      - name: controller
        command:
        - /app/conduit-operator
        args:
        - -webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
        - -metrics-cert-path=/tmp/k8s-metrics-server/serving-certs
        - -zap-devel=true
        - -instance-metadata=/app/instance-config/conduit-pod-metadata.yml
        image: 'ghcr.io/conduitio/conduit-operator:latest'
        imagePullPolicy: 'Always'
        livenessProbe:
          httpGet:
            path: /healthz
            port: 8081
          initialDelaySeconds: 16
          periodSeconds: 20
        ports:
        - containerPort: 9443
          name: webhook-server
          protocol: TCP
        readinessProbe:
          httpGet:
            path: /readyz
            port: 8081
          initialDelaySeconds: 5
          periodSeconds: 10
        resources:
          limits:
            cpu: 500m
            memory: 128Mi
          requests:
            cpu: 10m
            memory: 64Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
        volumeMounts:
        - mountPath: /tmp/k8s-webhook-server/serving-certs
          name: webhook-cert
          readOnly: true
        - mountPath: /tmp/k8s-metrics-server/serving-certs
          name: metrics-cert
          readOnly: true
        - mountPath: /app/instance-config
          name: 'release-name-conduit-operator-instance-config'
          readOnly: true
      securityContext:
        runAsNonRoot: true
      serviceAccountName: 'release-name-conduit-operator-controller-manager'
      terminationGracePeriodSeconds: 10
      volumes:
      - name: webhook-cert
        secret:
          defaultMode: 420
          secretName: webhook-server-cert
      - name: metrics-cert
        secret:
          defaultMode: 420
          secretName: metrics-server-cert
      - name: 'release-name-conduit-operator-instance-config'
        configMap:
           name: 'release-name-conduit-operator-instance-config'
```
</summary>


### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/conduitio/conduit-operator/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
