### PR TITLE
Move helm release to separate workflow

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,40 @@
+name: Helm Release
+on:
+  workflow_dispatch:
+    ref: main
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  build-push-helm-chart:
+    name: Build and push Helm chart pkg
+    runs-on: ubuntu-latest
+    env:
+      BUILD_DIR: charts/build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: gh-pages
+          path: ${{ env.BUILD_DIR }}
+      - name: Package Helm Chart
+        env:
+          WORKSPACE_BUILD_DIR: ${{ github.WORKSPACE }}/${{ env.BUILD_DIR}}
+        run: |
+          mkdir -p ${WORKSPACE_BUILD_DIR}
+          scripts/package-chart charts/conduit-operator ${WORKSPACE_BUILD_DIR} ${WORKSPACE_BUILD_DIR}/index.yaml
+          ls -all ${WORKSPACE_BUILD_DIR}
+          cat ${WORKSPACE_BUILD_DIR}/index.yaml
+      - name: Release Helm Chart
+        uses: peaceiris/actions-gh-pages@v4
+        env:
+          WORKSPACE_BUILD_DIR: ${{ github.WORKSPACE }}/${{ env.BUILD_DIR}}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.WORKSPACE_BUILD_DIR }}
+          keep_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,36 +8,6 @@ permissions:
   contents: write
 
 jobs:
-  build-push-helm-chart:
-    if: ${{ startsWith(github.ref, 'refs/tags') }}
-    name: Build and push Helm chart pkg
-    runs-on: ubuntu-latest
-    env:
-      BUILD_DIR: charts/build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository }}
-          ref: gh-pages
-          path: ${{ env.BUILD_DIR }}
-      - name: Package Helm Chart
-        env:
-          WORKSPACE_BUILD_DIR: ${{ github.WORKSPACE }}/${{ env.BUILD_DIR}}
-        run: |
-          mkdir -p ${WORKSPACE_BUILD_DIR}
-          scripts/package-chart charts/conduit-operator ${WORKSPACE_BUILD_DIR} ${WORKSPACE_BUILD_DIR}/index.yaml
-          ls -all ${WORKSPACE_BUILD_DIR}
-          cat ${WORKSPACE_BUILD_DIR}/index.yaml
-      - name: Release Helm Chart
-        uses: peaceiris/actions-gh-pages@v4
-        env:
-          WORKSPACE_BUILD_DIR: ${{ github.WORKSPACE }}/${{ env.BUILD_DIR}}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.WORKSPACE_BUILD_DIR }}
-          keep_files: true
-
   build-docker-image:
     name: Build Docker image
     runs-on: "ubuntu-latest-l-${{matrix.arch}}"


### PR DESCRIPTION
### Description

Pulled the helm chart release to a separate workflow. This will allow us to manually trigger helm releases if needed. Before this fix the only way to trigger a helm release would be to tag a new operator version.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio/conduit-operator/pulls) for the same update/change.
- [ ] I have written unit tests. [n/a]
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
